### PR TITLE
feat: prevent installing commands with the same names as buildin #13

### DIFF
--- a/internal/cmd/get/get.go
+++ b/internal/cmd/get/get.go
@@ -61,7 +61,7 @@ func run(ctx context.CLIContext, opts *options, cmd *cobra.Command, args []strin
 	// check if command isn't already registered
 	rootCmd := cmd.Root()
 	if foundCmd, _, _ := rootCmd.Find([]string{opts.As}); foundCmd != rootCmd {
-		return fmt.Errorf("The command '%s' is already registered", opts.As)
+		return fmt.Errorf("the command '%s' is already registered", opts.As)
 	}
 
 	if opts.Global {
@@ -145,7 +145,7 @@ func run(ctx context.CLIContext, opts *options, cmd *cobra.Command, args []strin
 		projectConfig.DefaultRegistry = depsMgr.DefaultRegistry
 
 		if err := schema.SaveProjectConfig(projectConfig); err != nil {
-			return fmt.Errorf("Unable to update dependencies in the %s file: %w", ctx.Config.ProjectConfigFileName, err)
+			return fmt.Errorf("unable to update dependencies in the %s file: %w", ctx.Config.ProjectConfigFileName, err)
 		} else {
 			log.Infof("Updated dependencies in the %s file", ctx.Config.ProjectConfigFileName)
 		}

--- a/internal/cmd/get/get_test.go
+++ b/internal/cmd/get/get_test.go
@@ -1,9 +1,12 @@
 package get
 
 import (
+	"errors"
 	"github.com/g2a-com/klio/internal/context"
+	"github.com/spf13/cobra"
 	"github.com/stretchr/testify/assert"
 	"os"
+	"path"
 	"path/filepath"
 	"testing"
 )
@@ -68,6 +71,65 @@ func Test_initialiseProjectInCurrentDir(t *testing.T) {
 				return
 			}
 			assert.EqualValues(t, tt.want, got)
+		})
+	}
+}
+
+func Test_run(t *testing.T) {
+	type args struct {
+		ctx  context.CLIContext
+		opts *options
+		cmd  *cobra.Command
+		args []string
+	}
+	ctx := context.CLIContext{
+		Config: context.CLIConfig{},
+		Paths:  context.Paths{
+			ProjectConfigFile: path.Join(os.TempDir(), "config.yaml"),
+			ProjectInstallDir: os.TempDir(),
+			GlobalInstallDir:  os.TempDir(),
+		},
+	}
+	rootCmdWithGet := cobra.Command{}
+	emptyCmd := cobra.Command{}
+
+	getCmd := NewCommand(ctx)
+	rootCmdWithGet.AddCommand(getCmd)
+
+	tests := []struct {
+		name  string
+		args  args
+		error error
+	}{
+		{
+			name: "should return error 'Cannot get already registered command 'get''",
+			args: args{
+				ctx: ctx,
+				opts: &options{
+					As: "get",
+				},
+				cmd:  &rootCmdWithGet,
+				args: nil,
+			},
+			error: errors.New("Cannot get already registered command 'get'"),
+		},
+		{
+			name: "should allow to register command 'get' since it is not registered",
+			args: args{
+				ctx: ctx,
+				opts: &options{
+					As: "get",
+				},
+				cmd:  &emptyCmd,
+				args: nil,
+			},
+			error: nil,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := run(tt.args.ctx, tt.args.opts, tt.args.cmd, tt.args.args)
+			assert.EqualValues(t, err, tt.error)
 		})
 	}
 }

--- a/internal/cmd/get/get_test.go
+++ b/internal/cmd/get/get_test.go
@@ -1,7 +1,7 @@
 package get
 
 import (
-	"errors"
+	"fmt"
 	"github.com/g2a-com/klio/internal/context"
 	"github.com/spf13/cobra"
 	"github.com/stretchr/testify/assert"
@@ -77,14 +77,12 @@ func Test_initialiseProjectInCurrentDir(t *testing.T) {
 
 func Test_run(t *testing.T) {
 	type args struct {
-		ctx  context.CLIContext
 		opts *options
 		cmd  *cobra.Command
-		args []string
 	}
 	ctx := context.CLIContext{
 		Config: context.CLIConfig{},
-		Paths:  context.Paths{
+		Paths: context.Paths{
 			ProjectConfigFile: path.Join(os.TempDir(), "config.yaml"),
 			ProjectInstallDir: os.TempDir(),
 			GlobalInstallDir:  os.TempDir(),
@@ -102,33 +100,29 @@ func Test_run(t *testing.T) {
 		error error
 	}{
 		{
-			name: "should return error 'Cannot get already registered command 'get''",
+			name: "should return error 'The command 'get' is already registered'",
 			args: args{
-				ctx: ctx,
 				opts: &options{
 					As: "get",
 				},
-				cmd:  &rootCmdWithGet,
-				args: nil,
+				cmd: &rootCmdWithGet,
 			},
-			error: errors.New("Cannot get already registered command 'get'"),
+			error: fmt.Errorf("The command 'get' is already registered"),
 		},
 		{
 			name: "should allow to register command 'get' since it is not registered",
 			args: args{
-				ctx: ctx,
 				opts: &options{
 					As: "get",
 				},
-				cmd:  &emptyCmd,
-				args: nil,
+				cmd: &emptyCmd,
 			},
 			error: nil,
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			err := run(tt.args.ctx, tt.args.opts, tt.args.cmd, tt.args.args)
+			err := run(ctx, tt.args.opts, tt.args.cmd, nil)
 			assert.EqualValues(t, err, tt.error)
 		})
 	}


### PR DESCRIPTION
### Context
Currently we allow to install command with name like `get` but we still uses buildin one. It would be nice to show feedback that this is not allowed operation. 

### Changes
* [x] Prevent installing commands with name already registered
* [x] Get handler return error and is handled later, it unifies way we handle errors and make unit testing easier
* [x] Unit tests

### Questions
1. My implementation prevent installing commands with name which was already registered. It means not only "buildin" commands but also registered before are not allowed. What do you think about that? 

### Actions
1. Resolves #13 