### PR TITLE
feat: restore compatibility with commands created for klio v2

### DIFF
--- a/internal/cmd/root/loader.go
+++ b/internal/cmd/root/loader.go
@@ -24,7 +24,7 @@ func loadExternalCommand(ctx context.CLIContext, rootCmd *cobra.Command, dep sch
 		return
 	}
 
-	cmdConfig, err := schema.LoadCommandConfig(filepath.Join(dep.Path, "manifest.yaml"))
+	cmdConfig, err := schema.LoadCommandConfig(filepath.Join(dep.Path, "command.yaml"))
 	if err != nil {
 		log.Warnf("Cannot load command: %s", err)
 		return


### PR DESCRIPTION
BREAKING CHANGE: manifest.yaml file was renamed back to command.yaml