### PR TITLE
fix: remove checksums from klio.yaml

### DIFF
--- a/internal/dependency/manager.go
+++ b/internal/dependency/manager.go
@@ -146,9 +146,6 @@ func (mgr *Manager) InstallDependency(dep schema.Dependency, scope ScopeType) (*
 	if entry.Checksum != "" && entry.Checksum != checksum {
 		return nil, fmt.Errorf(`checksum of the archive (%s) is different from the one specified in the regsitry (%s)`, checksum, entry.Checksum)
 	}
-	if dep.Checksum != "" && dep.Checksum != checksum {
-		return nil, fmt.Errorf(`checksum of the archive (%s) is different than expected (%s)`, checksum, dep.Checksum)
-	}
 
 	// Make sure that output dir exists and is empty
 	outputRelPath := filepath.Join("dependencies", checksum)
@@ -200,7 +197,6 @@ func (mgr *Manager) InstallDependency(dep schema.Dependency, scope ScopeType) (*
 	// Return info about installed dependency
 	result := dep
 	result.Version = entry.Version
-	result.Checksum = checksum
 
 	return &result, nil
 }

--- a/internal/schema/schema.go
+++ b/internal/schema/schema.go
@@ -194,7 +194,6 @@ type Dependency struct {
 	Name     string `yaml:"name,omitempty"`
 	Registry string `yaml:"registry,omitempty"`
 	Version  string `yaml:"version"`
-	Checksum string `yaml:"checksum"`
 	Alias    string `yaml:"-"`
 }
 


### PR DESCRIPTION
This feature is broken since it doesn't for cross-platform commands.

Affects #32