### PR TITLE
feat(#48): expose internal logger as klio package

### DIFF
--- a/pkg/log/log.go
+++ b/pkg/log/log.go
@@ -1,0 +1,60 @@
+package log
+
+import (
+	"github.com/g2a-com/klio/internal/log"
+)
+
+func setLevel(level string) {
+	log.SetLevel(level)
+}
+
+func setLevelFromEnv(level string) {
+	log.SetLevelFromEnv()
+}
+func IncreaseLevel(levels int) {
+	log.IncreaseLevel(levels)
+}
+func Warn(v ...interface{}) {
+	log.Warn(v)
+}
+func Warnf(format string, v ...interface{}) {
+	log.Warn(format, v)
+}
+func Debug(v ...interface{}) {
+	log.Debug(v)
+}
+func Debugf(format string, v ...interface{}) {
+	log.Debugf(format, v)
+}
+
+func Spam(v ...interface{}) {
+	log.Spam(v)
+}
+
+func Spamf(format string, v ...interface{}) {
+	log.Spamf(format, v)
+}
+func Verbose(v ...interface{}) {
+	log.Spam(v)
+}
+func Verbosef(format string, v ...interface{}) {
+	log.Spamf(format, v)
+}
+func Error(v ...interface{}) {
+	log.Error(v)
+}
+func Errorf(format string, v ...interface{}) {
+	log.Errorf(format, v)
+}
+func Log(level log.Level, v ...interface{}) {
+	log.Log(level, v)
+}
+func Logf(level log.Level, format string, v ...interface{}) {
+	log.Logf(level, format, v)
+}
+func Info(v ...interface{}) {
+	log.Info(v)
+}
+func Infof(format string, v ...interface{}) {
+	log.Infof(format, v)
+}


### PR DESCRIPTION
[![workerB](https://img.shields.io/endpoint?url=https%3A%2F%2Fworkerb.linearb.io%2Fv2%2Fbadge%2Fprivate%2FU2FsdGVkX19QG6zYsbzHdG0H1shXOSfs1L2a3S4hlgbxSzL6amke1Q2u3A4l%2Fcollaboration.svg%3FcacheSeconds%3D60)](https://workerb.linearb.io/v2/badge/collaboration-page?magicLinkId=MmoiJCV)