### PR TITLE
feat(g2a-com#52): add 'remove' command

### DIFF
--- a/internal/cmd/remove/remove.go
+++ b/internal/cmd/remove/remove.go
@@ -1,0 +1,79 @@
+package remove
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/g2a-com/klio/internal/context"
+	"github.com/g2a-com/klio/internal/dependency"
+	"github.com/g2a-com/klio/internal/log"
+	"github.com/g2a-com/klio/internal/scope"
+	"github.com/spf13/cobra"
+)
+
+// Options for a removeCommand command.
+type options struct {
+	Global bool
+}
+
+// NewCommand creates a new removeCommand command.
+func NewCommand(ctx context.CLIContext) *cobra.Command {
+	opts := &options{}
+	cmd := &cobra.Command{
+		Use:   "remove [command name]",
+		Short: "Remove installed commands",
+		Long:  fmt.Sprintf("Remove (%s removeCommand) will remove commands used with %s.", ctx.Config.CommandName, ctx.Config.CommandName),
+		Run: func(_ *cobra.Command, args []string) {
+			removeCommand(ctx, opts, args)
+		},
+	}
+
+	cmd.Flags().BoolVarP(&opts.Global, "global", "g", false, "remove command installed globally")
+
+	return cmd
+}
+
+func removeCommand(ctx context.CLIContext, opts *options, args []string) {
+	var removeScope scope.Scope
+
+	if opts.Global {
+		removeScope = scope.NewGlobal(ctx.Paths.GlobalInstallDir)
+	} else {
+		removeScope = scope.NewLocal(ctx.Paths.ProjectConfigFile, ctx.Paths.ProjectInstallDir, false, false)
+	}
+
+	err := removeScope.ValidatePaths()
+	if err != nil {
+		log.Fatalf("validation of paths failed: %s", err)
+	}
+	err = removeScope.Initialize(&ctx)
+	if err != nil {
+		log.Fatalf("scope initialization failed: %s", err)
+	}
+
+	var dependencies []dependency.Dependency
+	switch len(args) {
+	case 0:
+		dependencies = removeScope.GetImplicitDependencies()
+	case 1:
+		dependencies = []dependency.Dependency{
+			{
+				Alias: args[0],
+			},
+		}
+	default:
+		log.Fatalf("max one command can be provided for removal; provided %d", len(args))
+	}
+
+	err = removeScope.RemoveDependencies(dependencies)
+	if err != nil {
+		log.Fatalf("removing dependencies failed: %s", err)
+	}
+
+	removedDeps := removeScope.GetRemovedDependencies()
+	var formattingArray []string
+	for _, d := range removedDeps {
+		formattingArray = append(formattingArray, d.Alias)
+	}
+	log.Infof("All dependencies (%s) removed successfully", strings.Join(formattingArray, ","))
+}

--- a/internal/cmd/root/root.go
+++ b/internal/cmd/root/root.go
@@ -5,6 +5,7 @@ import (
 	"strings"
 
 	getCommand "github.com/g2a-com/klio/internal/cmd/get"
+	removeCommand "github.com/g2a-com/klio/internal/cmd/remove"
 	"github.com/g2a-com/klio/internal/context"
 	"github.com/g2a-com/klio/internal/dependency/manager"
 	"github.com/g2a-com/klio/internal/log"
@@ -46,6 +47,7 @@ func NewCommand(ctx context.CLIContext) *cobra.Command {
 
 	// Register builtin commands
 	rootCommand.AddCommand(getCommand.NewCommand(ctx))
+	rootCommand.AddCommand(removeCommand.NewCommand(ctx))
 
 	// Register external commands
 	for _, dep := range commands {

--- a/internal/scope/common.go
+++ b/internal/scope/common.go
@@ -13,6 +13,8 @@ type Scope interface {
 	GetImplicitDependencies() []dependency.Dependency
 	InstallDependencies([]dependency.Dependency) error
 	GetInstalledDependencies() []dependency.Dependency
+	RemoveDependencies([]dependency.Dependency) error
+	GetRemovedDependencies() []dependency.Dependency
 }
 
 func installDependencies(depsMgr *manager.Manager, toInstall []dependency.Dependency, installDir string) ([]dependency.Dependency, error) {
@@ -34,4 +36,21 @@ func installDependencies(depsMgr *manager.Manager, toInstall []dependency.Depend
 	}
 
 	return installedDeps, nil
+}
+
+func removeDependencies(depsMgr *manager.Manager, toRemove []dependency.Dependency, installDir string) []dependency.Dependency {
+	var removedDeps []dependency.Dependency
+
+	for _, dep := range toRemove {
+
+		if err := depsMgr.RemoveDependency(&dep, installDir); err != nil {
+			log.Fatalf("Failed to remove %s: %s", dep.Alias, err)
+		}
+
+		log.Infof("Removed %s", dep.Alias)
+
+		removedDeps = append(removedDeps, dep)
+	}
+
+	return removedDeps
 }

--- a/internal/scope/global.go
+++ b/internal/scope/global.go
@@ -16,6 +16,7 @@ type global struct {
 	os                afero.Fs
 	dependencyManager *manager.Manager
 	installedDeps     []dependency.Dependency
+	removedDeps       []dependency.Dependency
 	installDir        string
 }
 
@@ -67,4 +68,21 @@ func (g *global) InstallDependencies(listOfCommands []dependency.Dependency) err
 
 func (g *global) GetInstalledDependencies() []dependency.Dependency {
 	return g.installedDeps
+}
+
+func (g *global) RemoveDependencies(listOfCommands []dependency.Dependency) error {
+	if len(listOfCommands) != allowedNumberOfGlobalCommands {
+		return fmt.Errorf("wrong number of commands provided; provided %d, expected %d",
+			len(listOfCommands), allowedNumberOfGlobalCommands)
+	}
+
+	dep := listOfCommands
+
+	g.removedDeps = removeDependencies(g.dependencyManager, dep, g.installDir)
+
+	return nil
+}
+
+func (g *global) GetRemovedDependencies() []dependency.Dependency {
+	return g.removedDeps
 }

--- a/internal/scope/local.go
+++ b/internal/scope/local.go
@@ -21,6 +21,7 @@ type local struct {
 	projectConfig     *project.Config
 	dependencyManager *manager.Manager
 	installedDeps     []dependency.Dependency
+	removedDeps       []dependency.Dependency
 	os                afero.Fs
 	projectConfigFile string
 	installDir        string
@@ -129,4 +130,18 @@ func (l *local) InstallDependencies(listOfCommands []dependency.Dependency) erro
 
 func (l *local) GetInstalledDependencies() []dependency.Dependency {
 	return l.installedDeps
+}
+
+func (l *local) RemoveDependencies(listOfCommands []dependency.Dependency) error {
+	if len(listOfCommands) == 0 {
+		return fmt.Errorf("no dependencies provided for the project")
+	}
+
+	l.removedDeps = removeDependencies(l.dependencyManager, listOfCommands, l.installDir)
+
+	return nil
+}
+
+func (l *local) GetRemovedDependencies() []dependency.Dependency {
+	return l.removedDeps
 }


### PR DESCRIPTION
Added:
* when installing new commands, if a new version is downloaded, the old one is removed from the filesystem
* remove command:
  * klio remove -> removes the files of all commands specified in `klio.yaml` from the filesystem, deletes entries from `dependency.json`, leaves `klio.yaml` untouched
  * klio remove COMMAND -> same as above, just for 1 command
  * klio remove COMMAND -g -> same as above, just for global scope
  * If files are not found in the filesystem, it's assumed they where deleted manually (a log is displayed with debug level)
